### PR TITLE
add opaque pointer for send/recv

### DIFF
--- a/example/main.c
+++ b/example/main.c
@@ -4,8 +4,8 @@
 
 #include "slip.h"
 
-void recv_message(uint8_t *data, uint32_t size);
-uint8_t write_byte(uint8_t byte);
+void recv_message(void *state, uint8_t *data, uint32_t size);
+uint8_t write_byte(void *state, uint8_t byte);
 
 static uint8_t buf[100];
 
@@ -13,6 +13,7 @@ static const slip_descriptor_s slip_descriptor = {
         .buf = buf,
         .buf_size = sizeof(buf),
         .crc_seed = 0xFFFF,
+        .send_recv_state = NULL,
         .recv_message = recv_message,
         .write_byte = write_byte,
 };
@@ -36,7 +37,7 @@ int main(void)
         return 0;
 }
 
-void recv_message(uint8_t *data, uint32_t size)
+void recv_message(void *state, uint8_t *data, uint32_t size)
 {
         char recv_buf[size + 1];
 
@@ -46,7 +47,7 @@ void recv_message(uint8_t *data, uint32_t size)
         printf("RECV: %s\n", recv_buf);
 }
 
-uint8_t write_byte(uint8_t byte) 
+uint8_t write_byte(void *state, uint8_t byte) 
 {
         printf("TX: %02X\n", byte);
         return 1;

--- a/example_loopback/main.c
+++ b/example_loopback/main.c
@@ -4,8 +4,8 @@
 
 #include "slip.h"
 
-void recv_message(uint8_t *data, uint32_t size);
-uint8_t write_byte(uint8_t byte);
+void recv_message(void *state, uint8_t *data, uint32_t size);
+uint8_t write_byte(void *state, uint8_t byte);
 
 static uint8_t buf[100];
 
@@ -13,6 +13,7 @@ static const slip_descriptor_s slip_descriptor = {
         .buf = buf,
         .buf_size = sizeof(buf),
         .crc_seed = 0xFFFF,
+        .send_recv_state = NULL,
         .recv_message = recv_message,
         .write_byte = write_byte,
 };
@@ -45,7 +46,7 @@ int main(void)
         return 0;
 }
 
-void recv_message(uint8_t *data, uint32_t size)
+void recv_message(void *state, uint8_t *data, uint32_t size)
 {
         char recv_buf[size + 1];
 
@@ -55,7 +56,7 @@ void recv_message(uint8_t *data, uint32_t size)
         printf("RECV: %s\n", recv_buf);
 }
 
-uint8_t write_byte(uint8_t byte) 
+uint8_t write_byte(void *state, uint8_t byte) 
 {
         loopback_buf[loopback_buf_index++] = byte;
         return 1;

--- a/slip.c
+++ b/slip.c
@@ -138,6 +138,7 @@ slip_error_t slip_read_byte(slip_handler_s *slip, uint8_t byte)
                         if (slip->size >= 2) {
                                 if (slip->crc == 0) {
                                         slip->descriptor->recv_message(
+                                                slip->descriptor->send_recv_state, 
                                                 slip->descriptor->buf,
                                                 slip->size - 2
                                                 );
@@ -198,10 +199,10 @@ static uint8_t write_encoded_byte(slip_handler_s *slip, uint8_t byte)
         }
 
         if (escape != 0) {
-                if (slip->descriptor->write_byte(SLIP_SPECIAL_BYTE_ESC) == 0)
+                if (slip->descriptor->write_byte(slip->descriptor->send_recv_state, SLIP_SPECIAL_BYTE_ESC) == 0)
                         return 0;
         }
-        if (slip->descriptor->write_byte(byte) == 0)
+        if (slip->descriptor->write_byte(slip->descriptor->send_recv_state, byte) == 0)
                 return 0;
         
         return 1;
@@ -217,7 +218,7 @@ slip_error_t slip_send_message(slip_handler_s *slip, uint8_t *data, uint32_t siz
         assert(data != NULL);
         assert(slip != NULL);
 
-        if (slip->descriptor->write_byte(SLIP_SPECIAL_BYTE_END) == 0)
+        if (slip->descriptor->write_byte(slip->descriptor->send_recv_state, SLIP_SPECIAL_BYTE_END) == 0)
                 return SLIP_ERROR_BUFFER_OVERFLOW;
 
         crc = slip->descriptor->crc_seed;
@@ -238,7 +239,7 @@ slip_error_t slip_send_message(slip_handler_s *slip, uint8_t *data, uint32_t siz
                         return SLIP_ERROR_BUFFER_OVERFLOW;
         }
 
-        if (slip->descriptor->write_byte(SLIP_SPECIAL_BYTE_END) == 0)
+        if (slip->descriptor->write_byte(slip->descriptor->send_recv_state, SLIP_SPECIAL_BYTE_END) == 0)
                 return SLIP_ERROR_BUFFER_OVERFLOW;
 
         return SLIP_NO_ERROR;

--- a/slip.h
+++ b/slip.h
@@ -50,8 +50,9 @@ typedef struct {
         uint32_t buf_size;
         uint16_t crc_seed;
         
-        void (*recv_message)(uint8_t *data, uint32_t size);
-        uint8_t (*write_byte)(uint8_t byte);
+        void *send_recv_state;
+        void (*recv_message)(void *send_recv_state, uint8_t *data, uint32_t size);
+        uint8_t (*write_byte)(void *send_recv_state, uint8_t byte);
 } slip_descriptor_s;
 
 typedef struct {


### PR DESCRIPTION
In order to have state (other than global) for send and receive, pass it via an opaque pointer.  One example would be using a network socket for send and receive.